### PR TITLE
Refactor/stream (#28)

### DIFF
--- a/src/HttpMessage/CreateResourceFromStringTrait.php
+++ b/src/HttpMessage/CreateResourceFromStringTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kaspi\HttpMessage;
+
+trait CreateResourceFromStringTrait
+{
+    /**
+     * @return resource
+     */
+    private static function resourceFromString(string $body, string $fileName = 'php://temp', string $mode = 'r+b')
+    {
+        $resource = ($r = @\fopen($fileName, $mode)) !== false
+            ? $r
+            : throw new \RuntimeException('Cannot open from '.$fileName.' ['.(\error_get_last()['message'] ?? '').']');
+        \fwrite($resource, $body);
+        \fseek($resource, 0);
+
+        return $resource;
+    }
+}

--- a/src/HttpMessage/HttpFactory.php
+++ b/src/HttpMessage/HttpFactory.php
@@ -22,6 +22,8 @@ use Psr\Http\Message\UriInterface;
  */
 class HttpFactory implements RequestFactoryInterface, ResponseFactoryInterface, ServerRequestFactoryInterface, StreamFactoryInterface, UploadedFileFactoryInterface, UriFactoryInterface
 {
+    use CreateResourceFromStringTrait;
+
     public function createRequest(string $method, $uri): RequestInterface
     {
         return new Request(method: $method, uri: $uri);
@@ -39,7 +41,7 @@ class HttpFactory implements RequestFactoryInterface, ResponseFactoryInterface, 
 
     public function createStream(string $content = ''): StreamInterface
     {
-        return new Stream(body: $content);
+        return new Stream(resource: self::resourceFromString($content));
     }
 
     public function createStreamFromFile(string $filename, string $mode = 'rb'): StreamInterface

--- a/src/HttpMessage/Message.php
+++ b/src/HttpMessage/Message.php
@@ -12,16 +12,9 @@ class Message implements MessageInterface
 {
     private string $version;
     private array $headers = [];
-    private StreamInterface $body;
 
-    /**
-     * @param resource|StreamInterface|string $body
-     */
-    public function __construct($body = '', array $headers = [], string $protocolVersion = '1.1')
+    public function __construct(private StreamInterface $body, array $headers = [], string $protocolVersion = '1.1')
     {
-        $this->body = $body instanceof StreamInterface
-            ? $body
-            : new Stream($body);
         $this->addHeaders($headers);
         $this->checkProtocolVersion($protocolVersion);
         $this->version = $protocolVersion;

--- a/src/HttpMessage/Request.php
+++ b/src/HttpMessage/Request.php
@@ -5,24 +5,27 @@ declare(strict_types=1);
 namespace Kaspi\HttpMessage;
 
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
 
 class Request extends Message implements RequestInterface
 {
+    use CreateResourceFromStringTrait;
+
     protected ?string $requestTarget = null;
     private string $method;
     private UriInterface $uri;
 
-    /**
-     * @param \Psr\Http\Message\StreamInterface|resource|string $body
-     */
     public function __construct(
         string $method = 'GET',
         string|UriInterface $uri = '',
-        $body = '',
+        StreamInterface|string $body = '',
         array $headers = [],
         string $protocolVersion = '1.1'
     ) {
+        $body = \is_string($body)
+            ? new Stream(self::resourceFromString($body))
+            : $body;
         parent::__construct($body, $headers, $protocolVersion);
         $this->method = $method;
         $this->uri = \is_string($uri) ? new Uri($uri) : $uri;

--- a/src/HttpMessage/Response.php
+++ b/src/HttpMessage/Response.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Kaspi\HttpMessage;
 
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 class Response extends Message implements ResponseInterface
 {
+    use CreateResourceFromStringTrait;
+
     private const PHRASE = [
         100 => 'Continue',
         101 => 'Switching Protocols',
@@ -63,10 +66,13 @@ class Response extends Message implements ResponseInterface
     public function __construct(
         private int $code = 200,
         private ?string $reasonPhrase = null,
-        mixed $body = '',
+        StreamInterface|string $body = '',
         array $headers = [],
         string $protocolVersion = '1.1'
     ) {
+        $body = \is_string($body)
+            ? new Stream(self::resourceFromString($body))
+            : $body;
         parent::__construct($body, $headers, $protocolVersion);
         $this->checkStatusCode($this->code);
 

--- a/src/HttpMessage/ServerRequest.php
+++ b/src/HttpMessage/ServerRequest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Kaspi\HttpMessage;
 
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -23,7 +24,7 @@ class ServerRequest extends Request implements ServerRequestInterface
     public function __construct(
         string $method = 'GET',
         string|UriInterface $uri = '',
-        $body = '',
+        StreamInterface|string $body = '',
         array $headers = [],
         string $protocolVersion = '1.1',
         private readonly array $serverParams = [],

--- a/tests/Datasets/message_body.php
+++ b/tests/Datasets/message_body.php
@@ -2,15 +2,17 @@
 
 declare(strict_types=1);
 
-use Kaspi\HttpMessage\Message;
-use Kaspi\HttpMessage\Stream;
+use Tests\Kaspi\HttpMessage\StreamAdapter;
 
 \dataset('message_body_success', [
     'from string' => [
         'body' => 'hello',
         'contents' => 'hello',
     ],
-    'from StreamInterface' => [new Stream('welcome to class'), 'welcome to class'],
+    'from StreamInterface' => [
+        'body' => StreamAdapter::make('welcome to class'),
+        'contents' => 'welcome to class',
+    ],
 ]);
 
 \dataset('message_body_wrong', [
@@ -18,5 +20,5 @@ use Kaspi\HttpMessage\Stream;
     'float' => ['body' => 1.234],
     'int' => ['body' => 0xFF],
     'array' => ['body' => []],
-    'class' => ['body' => new Message()],
+    'class' => ['body' => new stdClass()],
 ]);

--- a/tests/Datasets/request.php
+++ b/tests/Datasets/request.php
@@ -12,7 +12,7 @@ use Kaspi\HttpMessage\Uri;
             'uri' => '',
             'expectUri' => '',
         ],
-        'set #' => [
+        'set #2' => [
             'method' => 'GET',
             'uri' => new Uri('https://php.org:443/index.php'),
             'expectUri' => 'https://php.org/index.php',
@@ -29,7 +29,7 @@ use Kaspi\HttpMessage\Uri;
             'srvParams' => [],
             'expectUri' => '',
         ],
-        'set #' => [
+        'set #2' => [
             'method' => 'GET',
             'uri' => new Uri('https://php.org:443/index.php'),
             'srvParams' => ['test1', 'test2' => ['list', 'info']],

--- a/tests/Feature/CreateResourceFromStringTest.php
+++ b/tests/Feature/CreateResourceFromStringTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+use Kaspi\HttpMessage\CreateResourceFromStringTrait;
+use Kaspi\HttpMessage\Stream;
+use org\bovigo\vfs\vfsStream;
+
+\describe('Test for '.CreateResourceFromStringTrait::class, function () {
+    \beforeEach(function () {
+        $this->mockClass = new class() {
+            use CreateResourceFromStringTrait;
+
+            public function make(string $content, string $file, string $mode)
+            {
+                return self::resourceFromString($content, $file, $mode);
+            }
+        };
+    });
+
+    \it('Success create', function (string $content, string $file, string $mode) {
+        $stream = new Stream($this->mockClass->make($content, $file, $mode));
+
+        \expect($stream->getContents())->toBe($content)
+            ->and($stream->getMetadata('uri'))->toBe($file)
+        ;
+    })
+        ->with([
+            'in php temporary file' => [
+                'content' => 'Hello world',
+                'file' => 'php://temp',
+                'mode' => 'rb+',
+            ],
+            'in memory' => [
+                'content' => 'Hello world',
+                'file' => 'php://memory',
+                'mode' => 'rb+',
+            ],
+            'file in virtual file system' => [
+                'content' => 'Hello world',
+                'file' => vfsStream::newFile('f')->at(vfsStream::setup())->url(),
+                'mode' => 'rb+',
+            ],
+        ])
+    ;
+
+    \it('fail', function ($file, $mode) {
+        \set_error_handler(static fn () => false);
+
+        new class($file, $mode) {
+            use CreateResourceFromStringTrait;
+
+            public function __construct($file, $mode)
+            {
+                \var_dump(self::resourceFromString('ok', $file, $mode));
+            }
+        };
+    })
+        ->throws(RuntimeException::class)
+        ->with([
+            'set write to HTTP' => [
+                'file' => 'http://0.0.0.0',
+                'mode' => 'w+',
+            ],
+            'set read from undefined file' => [
+                'file' => '/tmp/'.\uniqid('x', true),
+                'mode' => 'rb',
+            ],
+        ])
+    ;
+})
+    ->covers(CreateResourceFromStringTrait::class, Stream::class);

--- a/tests/Feature/HttpFactory/HttpFactoryTest.php
+++ b/tests/Feature/HttpFactory/HttpFactoryTest.php
@@ -16,6 +16,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UriInterface;
+use Tests\Kaspi\HttpMessage\StreamAdapter;
 
 \describe('Test for '.HttpFactory::class, function () {
     \describe('createRequest', function () {
@@ -169,12 +170,12 @@ use Psr\Http\Message\UriInterface;
     })
         ->with([
             'null init size' => [
-                'stream' => new Stream('file'),
+                'stream' => StreamAdapter::make('file'),
                 'size' => null,
                 'expectSize' => 4,
             ],
             'init size' => [
-                'stream' => new Stream('file'),
+                'stream' => StreamAdapter::make('file'),
                 'size' => 10,
                 'expectSize' => 10,
             ],

--- a/tests/Feature/Message/MessageBodyTest.php
+++ b/tests/Feature/Message/MessageBodyTest.php
@@ -2,24 +2,26 @@
 
 declare(strict_types=1);
 
+use Kaspi\HttpMessage\CreateResourceFromStringTrait;
 use Kaspi\HttpMessage\Message;
 use Kaspi\HttpMessage\Stream;
 use Psr\Http\Message\StreamInterface;
+use Tests\Kaspi\HttpMessage\StreamAdapter;
 
 \describe('Method getBody, withBody for '.Message::class, function () {
     \it('method getBody', function () {
-        $message = new Message();
+        $message = new Message(StreamAdapter::make());
         \expect($message->getBody())->toBeInstanceOf(StreamInterface::class)
             ->and($message->getBody())->toBeInstanceOf(Stream::class)
         ;
     });
 
     \it('method withBody', function () {
-        $message = new Message();
-        $newMessage = $message->withBody(new Stream(''));
+        $message = new Message(StreamAdapter::make());
+        $newMessage = $message->withBody(StreamAdapter::make());
 
         \expect($message)->not->toBe($newMessage);
     });
 })
-    ->covers(Message::class, Stream::class)
+    ->covers(Message::class, Stream::class, CreateResourceFromStringTrait::class)
 ;

--- a/tests/Feature/Message/MessageHeaderExceptionTest.php
+++ b/tests/Feature/Message/MessageHeaderExceptionTest.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
+use Kaspi\HttpMessage\CreateResourceFromStringTrait;
 use Kaspi\HttpMessage\Message;
 use Kaspi\HttpMessage\Stream;
+use Tests\Kaspi\HttpMessage\StreamAdapter;
 
 \describe('Exception for headers methods', function () {
     \it('Header name must be RFC 7230 compatible', function (string $name, mixed $value) {
-        (new Message())->withHeader($name, $value);
+        (new Message(StreamAdapter::make('')))->withHeader($name, $value);
     })->throws(
         InvalidArgumentException::class,
         'RFC 7230 compatible'
@@ -22,7 +24,7 @@ use Kaspi\HttpMessage\Stream;
     ;
 
     \it('Header name or values is empty value', function ($name, $values) {
-        (new Message())->withHeader($name, $values);
+        (new Message(StreamAdapter::make('')))->withHeader($name, $values);
     })->throws(InvalidArgumentException::class)
         ->with([
             'empty header name' => ['', ['ok']],
@@ -31,9 +33,9 @@ use Kaspi\HttpMessage\Stream;
     ;
 
     \it('Get header empty name', function () {
-        (new Message())->getHeader('');
+        (new Message(StreamAdapter::make('')))->getHeader('');
     })->throws(
         InvalidArgumentException::class,
         'Header name is empty string'
     );
-})->covers(Message::class, Stream::class);
+})->covers(Message::class, Stream::class, CreateResourceFromStringTrait::class);

--- a/tests/Feature/Message/MessageHeadersTest.php
+++ b/tests/Feature/Message/MessageHeadersTest.php
@@ -2,20 +2,22 @@
 
 declare(strict_types=1);
 
+use Kaspi\HttpMessage\CreateResourceFromStringTrait;
 use Kaspi\HttpMessage\Message;
 use Kaspi\HttpMessage\Stream;
+use Tests\Kaspi\HttpMessage\StreamAdapter;
 
 \describe('Methods getHeaders, getHeader, getHeaderLine, withHeader, withAddedHeader, withoutHeader', function () {
     \it('empty headers', function () {
-        \expect((new Message())->getHeaders())->toBe([]);
+        \expect((new Message(StreamAdapter::make()))->getHeaders())->toBe([]);
     });
 
     \it('no header by name', function () {
-        \expect((new Message())->getHeader('ok'))->toBe([]);
+        \expect((new Message(StreamAdapter::make()))->getHeader('ok'))->toBe([]);
     });
 
     \it('Method withHeader', function () {
-        $message = new Message();
+        $message = new Message(StreamAdapter::make());
         $newMessage = $message->withHeader('ok', 123456);
 
         \expect($newMessage)->not->toBe($message)
@@ -37,7 +39,7 @@ use Kaspi\HttpMessage\Stream;
     });
 
     \it('WithHeader update header values', function () {
-        $message = new Message();
+        $message = new Message(StreamAdapter::make());
         $newMessage = $message->withHeader('OKa', [" \tFoo   \t", 'Bar']);
 
         \expect($newMessage)->not->toBe($message)
@@ -52,7 +54,7 @@ use Kaspi\HttpMessage\Stream;
     });
 
     \it('method withoutHeader', function () {
-        $message = (new Message())->withHeader('Bar', 'Baz');
+        $message = (new Message(StreamAdapter::make()))->withHeader('Bar', 'Baz');
 
         \expect($message->withoutHeader('x')->getHeaders())->toBe(['Bar' => ['Baz']])
             ->and($message->withoutHeader('Bar')->getHeaders())->toBe([])
@@ -60,7 +62,7 @@ use Kaspi\HttpMessage\Stream;
     });
 
     \it('method withAddedHeader', function () {
-        $message = (new Message())->withHeader('Bar', 'Baz');
+        $message = (new Message(StreamAdapter::make()))->withHeader('Bar', 'Baz');
         $newMessage = $message->withAddedHeader('bar', 'Foo');
 
         \expect($newMessage->getHeaders())->toBe(['Bar' => ['Baz', 'Foo']]);
@@ -71,7 +73,7 @@ use Kaspi\HttpMessage\Stream;
     });
 
     \it('method hasHeader, getHeader with header name "0"', function () {
-        $message = (new Message())->withHeader('0', 'Baz');
+        $message = (new Message(StreamAdapter::make()))->withHeader('0', 'Baz');
 
         \expect($message->hasHeader('0'))->toBeTrue()
             ->and($message->hasHeader('false'))->toBeFalse()
@@ -104,7 +106,7 @@ use Kaspi\HttpMessage\Stream;
     });
 
     \it('Values in header empty value', function (string $name, mixed $value, array $expect) {
-        $m = (new Message())->withHeader($name, $value);
+        $m = (new Message(StreamAdapter::make()))->withHeader($name, $value);
 
         \expect($m->getHeader($name))->toBe($expect);
     })
@@ -116,11 +118,11 @@ use Kaspi\HttpMessage\Stream;
 
     \it('Header values maybe empty string', function () {
         \expect(
-            (new Message())
+            (new Message(StreamAdapter::make()))
                 ->withHeader('foo', ['Baz', "\t\t   \t", 'Bar'])
                 ->getHeader('foo')
         )->toBe(['Baz', '', 'Bar']);
     });
 })
-    ->covers(Message::class, Stream::class)
+    ->covers(Message::class, Stream::class, CreateResourceFromStringTrait::class)
 ;

--- a/tests/Feature/Message/MessageProtocolTest.php
+++ b/tests/Feature/Message/MessageProtocolTest.php
@@ -2,18 +2,20 @@
 
 declare(strict_types=1);
 
+use Kaspi\HttpMessage\CreateResourceFromStringTrait;
 use Kaspi\HttpMessage\Message;
 use Kaspi\HttpMessage\Stream;
+use Tests\Kaspi\HttpMessage\StreamAdapter;
 
 \describe('Methods getProtocolVersion, withProtocolVersion for '.Message::class, function () {
     \it('default version', function () {
-        \expect((new Message())->getProtocolVersion())->toBeString()
+        \expect((new Message(StreamAdapter::make()))->getProtocolVersion())->toBeString()
             ->toBe('1.1')
         ;
     });
 
     \it('withProtocol', function () {
-        $message = new Message();
+        $message = new Message(StreamAdapter::make());
         $newMessage = $message->withProtocolVersion('1.2');
 
         \expect($newMessage->getProtocolVersion())->toBeString()
@@ -28,8 +30,8 @@ use Kaspi\HttpMessage\Stream;
     });
 
     \it('withProtocol has exception', function () {
-        (new Message())->withProtocolVersion('1');
+        (new Message(StreamAdapter::make()))->withProtocolVersion('1');
     })->throws(InvalidArgumentException::class);
 })
-    ->covers(Message::class, Stream::class)
+    ->covers(Message::class, Stream::class, CreateResourceFromStringTrait::class)
 ;

--- a/tests/Feature/Request/RequestConstructorTest.php
+++ b/tests/Feature/Request/RequestConstructorTest.php
@@ -15,7 +15,7 @@ use org\bovigo\vfs\vfsStream;
         ->with('message_body_success')
         ->with([
             'from resource' => [
-                'body' => \fopen(vfsStream::newFile('f')->setContent('Virtual file!')->at(vfsStream::setup())->url(), 'rb'),
+                'body' => new Stream(\fopen(vfsStream::newFile('f')->setContent('Virtual file!')->at(vfsStream::setup())->url(), 'rb')),
                 'contents' => 'Virtual file!',
             ],
         ])
@@ -24,7 +24,7 @@ use org\bovigo\vfs\vfsStream;
     \it('wrong parameter body', function ($body) {
         new Request(body: $body);
     })
-        ->throws(InvalidArgumentException::class, 'Argument must be type "resource" or "string"')
+        ->throws(TypeError::class)
         ->with('message_body_wrong')
     ;
 

--- a/tests/Feature/Response/ResponseConstructorTest.php
+++ b/tests/Feature/Response/ResponseConstructorTest.php
@@ -15,7 +15,7 @@ use org\bovigo\vfs\vfsStream;
         ->with('message_body_success')
         ->with([
             'from resource' => [
-                'body' => \fopen(vfsStream::newFile('f')->setContent('Virtual file!')->at(vfsStream::setup())->url(), 'rb'),
+                'body' => new Stream(\fopen(vfsStream::newFile('f')->setContent('Virtual file!')->at(vfsStream::setup())->url(), 'rb')),
                 'contents' => 'Virtual file!',
             ],
         ])
@@ -24,7 +24,7 @@ use org\bovigo\vfs\vfsStream;
     \it('wrong parameter body', function ($body) {
         new Response(body: $body);
     })
-        ->throws(InvalidArgumentException::class, 'Argument must be type "resource" or "string"')
+        ->throws(TypeError::class)
         ->with('message_body_wrong')
     ;
 

--- a/tests/Feature/ServerRequest/ServerRequestConstructorTest.php
+++ b/tests/Feature/ServerRequest/ServerRequestConstructorTest.php
@@ -24,7 +24,7 @@ use Kaspi\HttpMessage\Uri;
     \it('fail body', function ($body) {
         new ServerRequest(body: $body);
     })
-        ->throws(InvalidArgumentException::class, 'Argument must be type "resource" or "string"')
+        ->throws(TypeError::class)
         ->with('message_body_wrong')
     ;
 

--- a/tests/Feature/ServerRequest/ServerRequestTest.php
+++ b/tests/Feature/ServerRequest/ServerRequestTest.php
@@ -65,7 +65,7 @@ use Psr\Http\Message\StreamInterface;
             'null' => ['parsedBody' => null],
             'array' => ['parsedBody' => ['hello' => 'world']],
             'object' => ['parsedBody' => (object) ['hello' => 'world']],
-            'object as class' => ['parsedBody' => new Stream('')],
+            'object as class' => ['parsedBody' => new stdClass()],
         ])
     ;
 

--- a/tests/Feature/Stream/StreamTest.php
+++ b/tests/Feature/Stream/StreamTest.php
@@ -2,8 +2,10 @@
 
 declare(strict_types=1);
 
+use Kaspi\HttpMessage\CreateResourceFromStringTrait;
 use Kaspi\HttpMessage\Stream;
 use Tests\Kaspi\HttpMessage\Feature\Stream\TestStream;
+use Tests\Kaspi\HttpMessage\StreamAdapter;
 
 \describe('Tests for '.Stream::class, function () {
     \it('Destructor unset related resource', function () {
@@ -53,14 +55,13 @@ use Tests\Kaspi\HttpMessage\Feature\Stream\TestStream;
     });
 
     \it('Create Stream from string', function () {
-        $stream = new Stream('Hello world!'.PHP_EOL.'--'.PHP_EOL);
+        $stream = StreamAdapter::make('Hello world!'.PHP_EOL.'--'.PHP_EOL);
 
         \expect($stream->isWritable())->toBeTrue()
             ->and($stream->isReadable())->toBeTrue()
             ->and($stream->isSeekable())->toBeTrue()
             ->and($stream->getMetadata())->toBeArray()
             ->and($stream->eof())->toBeFalse()
-            ->and($stream->getMetadata('uri'))->toBe('php://temp')
             ->and($stream->getContents())->toBe("Hello world!\n--\n")
             ->and($stream->eof())->toBeTrue()
         ;
@@ -97,7 +98,7 @@ use Tests\Kaspi\HttpMessage\Feature\Stream\TestStream;
     ;
 
     \it('Stream test methods Seek, Rewind, Eof, Read', function () {
-        $stream = new Stream('hello');
+        $stream = StreamAdapter::make('hello');
 
         \expect($stream->eof())->toBeFalse()
             ->and($stream->read(6))->toBe('hello')
@@ -116,7 +117,7 @@ use Tests\Kaspi\HttpMessage\Feature\Stream\TestStream;
     });
 
     \it('Seek as negative value', function () {
-        $stream = new Stream('hello');
+        $stream = StreamAdapter::make('hello');
         $stream->seek(-1);
         $stream->close();
     })->throws(RuntimeException::class, 'Cannot search for position');
@@ -170,7 +171,7 @@ use Tests\Kaspi\HttpMessage\Feature\Stream\TestStream;
     });
 
     \it('Stream method Detach', function () {
-        $stream = new Stream('abc');
+        $stream = StreamAdapter::make('abc');
         $resource = $stream->detach();
 
         \expect($resource)->toBeResource()
@@ -194,11 +195,11 @@ use Tests\Kaspi\HttpMessage\Feature\Stream\TestStream;
     })
         ->throws(RuntimeException::class)
         ->with([
-            'tell' => ['stream' => new Stream(''), 'method' => 'tell'],
-            'seek' => ['stream' => new Stream(''), 'method' => 'seek', 'args' => [0]],
-            'write' => ['stream' => new Stream(''), 'method' => 'write', 'args' => ['abc']],
-            'read' => ['stream' => new Stream(''), 'method' => 'read', 'args' => [1]],
-            'getContents' => ['stream' => new Stream(''), 'method' => 'getContents'],
+            'tell' => ['stream' => StreamAdapter::make(''), 'method' => 'tell'],
+            'seek' => ['stream' => StreamAdapter::make(''), 'method' => 'seek', 'args' => [0]],
+            'write' => ['stream' => StreamAdapter::make(''), 'method' => 'write', 'args' => ['abc']],
+            'read' => ['stream' => StreamAdapter::make(''), 'method' => 'read', 'args' => [1]],
+            'getContents' => ['stream' => StreamAdapter::make(''), 'method' => 'getContents'],
         ])
     ;
 
@@ -246,5 +247,5 @@ use Tests\Kaspi\HttpMessage\Feature\Stream\TestStream;
         ;
     });
 })
-    ->covers(Stream::class)
+    ->covers(Stream::class, CreateResourceFromStringTrait::class)
 ;

--- a/tests/Feature/UploadedFile/UploadedFileTest.php
+++ b/tests/Feature/UploadedFile/UploadedFileTest.php
@@ -2,12 +2,14 @@
 
 declare(strict_types=1);
 
+use Kaspi\HttpMessage\CreateResourceFromStringTrait;
 use Kaspi\HttpMessage\Stream;
 use Kaspi\HttpMessage\UploadedFile;
 use org\bovigo\vfs\content\LargeFileContent;
 use org\bovigo\vfs\vfsStream;
 use Psr\Http\Message\StreamInterface;
 use Psr\Http\Message\UploadedFileInterface;
+use Tests\Kaspi\HttpMessage\StreamAdapter;
 
 \describe('Tests for '.UploadedFile::class, function () {
     \describe('Constructor', function () {
@@ -35,7 +37,7 @@ use Psr\Http\Message\UploadedFileInterface;
         ;
 
         \it('available StreamInterface', function () {
-            \expect(new UploadedFile(new Stream(''), 0))
+            \expect(new UploadedFile(StreamAdapter::make(''), 0))
                 ->toBeInstanceOf(UploadedFileInterface::class)
             ;
         })
@@ -85,7 +87,7 @@ use Psr\Http\Message\UploadedFileInterface;
         ;
 
         \it('from stream', function () {
-            $stream = new Stream('');
+            $stream = StreamAdapter::make('');
             $uploadedFile = (new UploadedFile($stream, \UPLOAD_ERR_OK));
             \expect($uploadedFile->getStream())
                 ->toBeInstanceOf(StreamInterface::class)
@@ -98,7 +100,9 @@ use Psr\Http\Message\UploadedFileInterface;
         })
             ->throws(RuntimeException::class, 'Uploaded file has error code: '.\UPLOAD_ERR_FORM_SIZE)
         ;
-    });
+    })
+        ->covers(CreateResourceFromStringTrait::class)
+    ;
 
     \describe('simple methods', function () {
         \it('method with null value', function () {

--- a/tests/StreamAdapter.php
+++ b/tests/StreamAdapter.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Kaspi\HttpMessage;
+
+use Kaspi\HttpMessage\CreateResourceFromStringTrait;
+use Kaspi\HttpMessage\Stream;
+use Psr\Http\Message\StreamInterface;
+
+class StreamAdapter
+{
+    use CreateResourceFromStringTrait;
+
+    public static function make(string $body = ''): StreamInterface
+    {
+        return new Stream(self::resourceFromString($body, 'php://memory'));
+    }
+}


### PR DESCRIPTION
* refactor: [Stream] Make Trait for resource from string.

* refactor: [Stream] Add the trait "CreateResourceFromStringTrait".

* refactor: [Stream] Constructor with parameter type resource only.

* refactor: [Message] Parameter name "body" has type StreamInterface only.

* refactor: [Request, Response, ServerRequest] Parameter name "body" has type StreamInterface or string only.

* refactor: [HttpFactory] Use trait CreateResourceFromStringTrait.

* refactor: [Stream] Code style.

* refactor: [CreateResourceFromString] Add params for "filename" and "mode" open stream.

* refactor: [Request, Response] Create a stream from string by trait method.

* test: [All] Update tests.

* refactor: [Message] Property promotion.