### PR TITLE
Fix regular expression and reason phrase must be compatible RFC 7230 …

### DIFF
--- a/src/HttpMessage/Message.php
+++ b/src/HttpMessage/Message.php
@@ -10,6 +10,8 @@ use Psr\Http\Message\UriInterface;
 
 class Message implements MessageInterface
 {
+    public const RFC7230_FIELD_TOKEN = '/^[\x09\x20-\x7E\x80-\xFF]*$/';
+
     private string $version;
     private array $headers = [];
 
@@ -213,7 +215,7 @@ class Message implements MessageInterface
 
         foreach ($valuesRaw as $value) {
             if ((!\is_numeric($value) && !\is_string($value))
-                || 1 !== \preg_match('/^[ \t\x21-\x7E\x80-\xFF]*$/', (string) $value)) {
+                || 1 !== \preg_match(self::RFC7230_FIELD_TOKEN, (string) $value)) {
                 $val = \var_export($value, true);
 
                 throw new \InvalidArgumentException('Header value must be RFC 7230 compatible. Got: '.$val);

--- a/src/HttpMessage/Uri.php
+++ b/src/HttpMessage/Uri.php
@@ -233,10 +233,10 @@ class Uri implements UriInterface
     protected static function encode(EncodeEnum $encode, string $value): string
     {
         $pattern = match ($encode) {
-            EncodeEnum::userinfo => '/(?:[^'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.'%]++|'.self::CHAR_PCT_ENCODED.')/',
-            EncodeEnum::path => '/(?:[^'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.'%:@\/]++|'.self::CHAR_PCT_ENCODED.')/',
+            EncodeEnum::userinfo => '/(?:[^'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.'%]+|'.self::CHAR_PCT_ENCODED.')/',
+            EncodeEnum::path => '/(?:[^'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.'%:@\/]+|'.self::CHAR_PCT_ENCODED.')/',
             EncodeEnum::fragment,
-            EncodeEnum::query => '/(?:[^'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.'%:@\/\?]++|'.self::CHAR_PCT_ENCODED.')/',
+            EncodeEnum::query => '/(?:[^'.self::CHAR_UNRESERVED.self::CHAR_SUB_DELIMS.'%:@\/\?]+|'.self::CHAR_PCT_ENCODED.')/',
         };
 
         return \preg_replace_callback($pattern, static fn (array $matches) => \rawurlencode($matches[0]), $value);

--- a/tests/Datasets/reason_phrase.php
+++ b/tests/Datasets/reason_phrase.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+\dataset('reason_phrase_success', [
+    'trimmed phrase' => ['reasonPhrase' => "\t all right   ", 'expect' => 'all right'],
+    'as is phrase with double space in middle' => ['reasonPhrase' => 'all  right', 'expect' => 'all  right'],
+    'as is phrase with tab in middle' => ['reasonPhrase' => 'all    right', 'expect' => 'all    right'],
+]);
+
+\dataset('reason_phrase_fail', [
+    'char 8' => ['reasonPhrase' => \chr(8)],
+    'new line in phrase' => ['reasonPhrase' => "\r"],
+    'carriage return in phrase' => ['reasonPhrase' => \chr(13)],
+]);

--- a/tests/Feature/Response/ResponseConstructorTest.php
+++ b/tests/Feature/Response/ResponseConstructorTest.php
@@ -47,6 +47,19 @@ use org\bovigo\vfs\vfsStream;
         ->throws(InvalidArgumentException::class)
         ->with('headers_wrong')
     ;
+
+    \it('Normalize reason phrase', function ($reasonPhrase, $expect) {
+        \expect((new Response(reasonPhrase: $reasonPhrase))->getReasonPhrase())->toBe($expect);
+    })
+        ->with('reason_phrase_success')
+    ;
+
+    \it('Wrong reason phrase', function ($reasonPhrase) {
+        new Response(reasonPhrase: $reasonPhrase);
+    })
+        ->throws(InvalidArgumentException::class)
+        ->with('reason_phrase_fail')
+    ;
 })
     ->covers(Response::class, Stream::class, Message::class, Uri::class)
 ;

--- a/tests/Feature/Response/ResponseTest.php
+++ b/tests/Feature/Response/ResponseTest.php
@@ -45,4 +45,19 @@ use Kaspi\HttpMessage\Stream;
             ->and($r2->getReasonPhrase())->toBe('Sorry i am not found your document right now')
         ;
     });
+
+    \it('Normalize reason phrase in withStatus', function ($reasonPhrase, $expect) {
+        \expect($r = (new Response())->withStatus(100, $reasonPhrase))
+            ->and($r->getReasonPhrase())->toBe($expect)
+        ;
+    })
+        ->with('reason_phrase_success')
+    ;
+
+    \it('Fail reason phrase in withStatus', function ($reasonPhrase) {
+        (new Response())->withStatus(100, $reasonPhrase);
+    })
+        ->throws(InvalidArgumentException::class)
+        ->with('reason_phrase_fail')
+    ;
 })->covers(Response::class, Message::class, Stream::class);


### PR DESCRIPTION
…(#35)

* fix: [Uri] Fix regexp for encode Uri components.

* fix: [Message] Fix regexp for test header name.

* feat: [Response] Response phrase must be RFC 7230 compatible.